### PR TITLE
fix: improve title case formatting

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -10,8 +10,19 @@ import { titleCase } from "title-case";
 export function toTitleCase(str: string): string {
   return str
     .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ")
     .split(" ")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .map((word) =>
+      word
+        .split(/([-'’])/g)
+        .map((part) =>
+          /[-'’]/.test(part)
+            ? part
+            : part.charAt(0).toUpperCase() + part.slice(1),
+        )
+        .join(""),
+    )
     .join(" ");
 }
 

--- a/test/utils/stringUtils.test.ts
+++ b/test/utils/stringUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { toTitleCase, cleanString } from "../../src/utils/stringUtils";
+
+describe("stringUtils", () => {
+  it("toTitleCase trims and handles apostrophes and hyphens", () => {
+    expect(toTitleCase("   o'neal   johnson ")).toBe("O'Neal Johnson");
+    expect(toTitleCase("mary-jane")).toBe("Mary-Jane");
+  });
+
+  it("cleanString trims and formats input", () => {
+    expect(cleanString("  hello WORLD  ")).toBe("Hello World");
+    expect(cleanString("greetings from space", "sentence")).toBe(
+      "Greetings from space",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- handle apostrophes, hyphens, and extra whitespace in `toTitleCase`
- add tests for `toTitleCase` and `cleanString`

## Testing
- `npm test test/utils/stringUtils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897893f20a8832aa9ca0add8952c3e1