### PR TITLE
Show closed notice only for explicitly closed shops

### DIFF
--- a/src/components/Sidebar/MapSidebar.tsx
+++ b/src/components/Sidebar/MapSidebar.tsx
@@ -162,7 +162,7 @@ const MapSidebar = () => {
                 </p>
               )}
 
-              {selectedShop.locationOpen !== false && (
+              {selectedShop.locationOpen === false && (
                 <span className="block bg-red-600 text-white text-xs font-bold rounded px-2 py-1 mt-2">
                   This location is permanently closed.
                 </span>

--- a/test/components/MapSidebar.test.tsx
+++ b/test/components/MapSidebar.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import MapSidebar from "../../src/components/Sidebar/MapSidebar";
+import { vi } from "vitest";
+
+vi.mock("../../src/context/ShopSidebarContext", () => ({
+  useShopSidebar: vi.fn(),
+}));
+
+vi.mock("../../src/context/authContext", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../../src/context/voteContext", () => ({
+  useVote: vi.fn(),
+}));
+
+vi.mock("../../src/context/modalContext", () => ({
+  useModal: () => ({ openSignupModal: vi.fn() }),
+}));
+
+vi.mock("../../src/context/toastContext", () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+import { useShopSidebar } from "../../src/context/ShopSidebarContext";
+import { useAuth } from "../../src/context/authContext";
+import { useVote } from "../../src/context/voteContext";
+
+describe("MapSidebar location status", () => {
+  const baseShop = {
+    shopId: 1,
+    shopName: "Test Shop",
+    address: "123 Main St",
+    createdBy: "Tester",
+  };
+
+  const sidebarValues = {
+    position: [0, 0] as [number, number],
+    sidebarOpen: true,
+    closeSidebar: vi.fn(),
+  };
+
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+    });
+    (useVote as jest.Mock).mockReturnValue({
+      votes: {},
+      addVote: vi.fn(),
+      getVotesForShop: vi.fn().mockResolvedValue(undefined),
+      submitVote: vi.fn(),
+      loadingVotes: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows closed notice when locationOpen is false", () => {
+    (useShopSidebar as jest.Mock).mockReturnValue({
+      ...sidebarValues,
+      selectedShop: { ...baseShop, locationOpen: false },
+    });
+
+    render(<MapSidebar />);
+    expect(
+      screen.getByText("This location is permanently closed."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show closed notice when locationOpen is true", () => {
+    (useShopSidebar as jest.Mock).mockReturnValue({
+      ...sidebarValues,
+      selectedShop: { ...baseShop, locationOpen: true },
+    });
+
+    render(<MapSidebar />);
+    expect(
+      screen.queryByText("This location is permanently closed."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show closed notice when locationOpen is undefined", () => {
+    (useShopSidebar as jest.Mock).mockReturnValue({
+      ...sidebarValues,
+      selectedShop: { ...baseShop },
+    });
+
+    render(<MapSidebar />);
+    expect(
+      screen.queryByText("This location is permanently closed."),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Fix MapSidebar logic to display closure warning only when `selectedShop.locationOpen` is explicitly `false`
- Add unit tests verifying the closure message appears only for closed shops and not for open or unspecified shops

## Testing
- `npm test` *(fails: Error mocking module; URL_INVALID: The URL 'undefined' is not in a valid format; FirebaseError: auth/invalid-api-key)*
- `npx vitest run test/components/MapSidebar.test.tsx`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899ea8a6d68832aadbb653c0761a36d