### PR TITLE
test: add filter toast test

### DIFF
--- a/src/components/Search/SearchBar.tsx
+++ b/src/components/Search/SearchBar.tsx
@@ -92,7 +92,7 @@ const SearchBar = ({ navRef }: SearchBarProps) => {
       addToast(`Showing ${shops.length} filtered shop(s).`, "success");
     }
 
-    const firstLoc = shops[0].locations?.[0];
+    const firstLoc = shops[0]?.locations?.[0];
     if (firstLoc) {
       setCenter([firstLoc.longitude, firstLoc.latitude]);
       setZoom(13);


### PR DESCRIPTION
## Summary
- add SearchBar test for filter change showing error toast
- ensure SearchBar handles empty filter results without crash

## Testing
- `npx vitest test/components/SearchBar.test.tsx`
- `npm test` *(fails: Firebase auth invalid API key; libsql URL invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6899e2eb70b0832abf333058579576cb